### PR TITLE
Environment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ A typical use of docsme is to update the CLI documentation in the `README.md` fi
 
 When used without parameters, the generated documentation is written to standard output.
 
+### Usage
+
 ```bash
 docsme [flags]
 ```

--- a/generate.go
+++ b/generate.go
@@ -33,6 +33,7 @@ func (m *mdgen) generate(cmd *cobra.Command, w io.Writer) error {
 	m.examples(cmd, buff)
 	m.additionalHelpTopics(cmd, buff)
 	m.flags(cmd, buff)
+	m.environment(cmd, buff)
 	m.seeAlso(cmd, buff)
 
 	if err := m.subcommands(cmd, buff); err != nil {
@@ -86,6 +87,7 @@ func (m *mdgen) long(cmd *cobra.Command, buff *bytes.Buffer) {
 
 func (m *mdgen) useLine(cmd *cobra.Command, buff *bytes.Buffer) {
 	if cmd.Runnable() {
+		fmt.Fprint(buff, m.heading(h2, "Usage"))
 		fmt.Fprintf(buff, "```bash\n%s\n```\n\n", cmd.UseLine())
 	}
 }
@@ -108,6 +110,23 @@ func (m *mdgen) flags(cmd *cobra.Command, buff *bytes.Buffer) {
 
 	formatFlags(cmd.NonInheritedFlags(), "Flags")
 	formatFlags(cmd.InheritedFlags(), "Global Flags")
+}
+
+func (m *mdgen) environment(cmd *cobra.Command, buff *bytes.Buffer) {
+	if !hasEnvironment(cmd) {
+		return
+	}
+
+	buff.WriteString(m.heading(h2, "Environment"))
+	fmt.Fprintln(buff, "```")
+
+	padding := envPadding(cmd)
+
+	for _, envvar := range envVariables(cmd) {
+		fmt.Fprintf(buff, "  %-*s   %s\n", padding, envvar.Name, envvar.Usage)
+	}
+
+	fmt.Fprint(buff, "```\n\n")
 }
 
 func (m *mdgen) examples(cmd *cobra.Command, buff *bytes.Buffer) {

--- a/releases/v0.2.0.md
+++ b/releases/v0.2.0.md
@@ -1,0 +1,12 @@
+**docsme** `v0.2.0` is here 🎉!
+
+This release includes:
+  * Environment section
+
+## New features
+
+### Environment section [#3](https://github.com/szkiba/docsme/issues/3)
+
+The new **Environment** section contains a list of environment variable names and descriptions. The list is collected from the command flags. If the flag has an annotation named `environment`, its value will be the environment variable name and the flag usage will be the description.
+
+The **Environment** section will be included in the generated documentation and the new `docsme.SetUsageTemplate(*cobra.Command)` function will also insert it into the command usage template.

--- a/template.go
+++ b/template.go
@@ -1,0 +1,90 @@
+package docsme
+
+import (
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var templateFuncsOnce sync.Once //nolint:gochecknoglobals
+
+// SetUsageTemplate adds an "Environment" section to the usage template of the command.
+// The Environment section contains a list of environment variable names and descriptions.
+// The list is taken from the flags of the command. If the flag has an annotation named "environment",
+// its value will be the name of the environment variable and the flag usage will be the description.
+func SetUsageTemplate(cmd *cobra.Command) {
+	templateFuncsOnce.Do(func() {
+		cobra.AddTemplateFuncs(templateFuncs())
+	})
+
+	tmpl := strings.Replace(cmd.UsageTemplate(), "{{if .HasHelpSubCommands}}", `{{if hasEnvironment .}}
+
+Environment:{{range $envvar := (envVariables .)}}
+  {{rpad $envvar.Name (envPadding $) }}{{$envvar.Usage}}{{end}}{{end}}{{if .HasHelpSubCommands}}`, 1)
+
+	cmd.SetUsageTemplate(tmpl)
+}
+
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"hasEnvironment": hasEnvironment,
+		"envPadding":     envPadding,
+		"envVariables":   envVariables,
+	}
+}
+
+func hasEnvironment(cmd *cobra.Command) bool {
+	found := false
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		found = found || len(envVariableFromAnnotation(f)) > 0
+	})
+
+	return found
+}
+
+func envPadding(cmd *cobra.Command) int {
+	padding := 0
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if name := envVariableFromAnnotation(f); len(name) > padding {
+			padding = len(name)
+		}
+	})
+
+	const minPadding = 3
+
+	return padding + minPadding
+}
+
+type variable struct {
+	Name  string
+	Usage string
+}
+
+func envVariables(cmd *cobra.Command) []*variable {
+	all := make([]*variable, 0)
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if name := envVariableFromAnnotation(f); len(name) != 0 {
+			all = append(all, &variable{Name: name, Usage: f.Usage})
+		}
+	})
+
+	return all
+}
+
+func envVariableFromAnnotation(flag *pflag.Flag) string {
+	if len(flag.Annotations) == 0 {
+		return ""
+	}
+
+	if value, has := flag.Annotations["environment"]; has && len(value) != 0 {
+		return value[0]
+	}
+
+	return ""
+}


### PR DESCRIPTION
The new **Environment** section contains a list of environment variable names and descriptions. The list is collected from the command flags. If the flag has an annotation named `environment`, its value will be the environment variable name and the flag usage will be the description.

The **Environment** section will be included in the generated documentation and the new `docsme.SetUsageTemplate(*cobra.Command)` function will also insert it into the command usage template.
